### PR TITLE
Update action.pl

### DIFF
--- a/action.pl
+++ b/action.pl
@@ -24,7 +24,7 @@ my $groupobj = RT::Group->new(RT->SystemUser);
 $groupobj->Load(118599); # 11859 is the group id of the VIP group
 my @accounts = split(', ', $groupobj->MemberEmailAddressesAsString());
 
-my $PRIORITY = 10;
+my $PRIORITY = 15;
 
 # See if the requestor is in the list of high priority accounts
 my @requestor_addresses = split(', ', $self->TicketObj->RequestorAddresses());


### PR DESCRIPTION
Going by the current numbering standard, 10 is normal, 15 is urgent, and 20 is critical. The current autoprioritization then, is not escalating requests from VIP members. Setting it to 15 should improve that.
